### PR TITLE
Keep _name in the main strings

### DIFF
--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -1,5 +1,7 @@
 <resources>
     <!-- General -->
+    <string name="app_name" translatable="false">Missed Notifications Reminder</string>
+    <string name="launcher_name" translatable="false">Missed Notifications Reminder</string>
     <string name="loading_message">loading…</string>
 
     <!-- Settings -->

--- a/app/src/release/res/values/titles.xml
+++ b/app/src/release/res/values/titles.xml
@@ -1,7 +1,0 @@
-<?xml version="1.0" encoding="utf-8"?>
-<resources>
-
-    <string name="app_name" translatable="false">Missed Notifications Reminder</string>
-    <string name="launcher_name" translatable="false">Missed Notifications Reminder</string>
-
-</resources>


### PR DESCRIPTION
Fixing F-Droid checkupdates:
```
DEBUG: Adding possible subdir app
DEBUG: fetch_real_name: Checking manifest at build/com.app.missednotificationsreminder/app/src/main/AndroidManifest.xml
DEBUG: ...couldn't get autoname
```